### PR TITLE
Battery notifier updated state file and suspension mechanism

### DIFF
--- a/check-batt
+++ b/check-batt
@@ -1,22 +1,74 @@
 #!/usr/bin/env bash
 
-BATTSTATUS=$(cat /sys/class/power_supply/BAT0/status)
-BATTPERC=$(cat /sys/class/power_supply/BAT0/capacity)
+BAT_NUM='1'
+STATUS_FILE=/tmp/check-bat.tmp
+BATTPERC=$(cat /sys/class/power_supply/BAT${BAT_NUM}/capacity)
+BATTSTATUS=$(cat /sys/class/power_supply/BAT${BAT_NUM}/status)
+LAST_STATUS=''
+LAST_NOTIF_LEVEL=0
+NOTIF_LEVEL=0
 
-notify() {
-    level=$1
-    msg=$2
-    DISPLAY=:0 /usr/bin/notify-send -u "$level" "POWER" "$msg"
+if [ -e $STATUS_FILE ] ; then
+	. $STATUS_FILE
+fi
+
+save_status() {
+	LAST_STATUS=$BATTSTATUS
+	echo "LAST_STATUS=${BATTSTATUS}" > $STATUS_FILE
+	echo "LAST_NOTIF_LEVEL=${NOTIF_LEVEL}" >> $STATUS_FILE
 }
 
-if [[ $BATTSTATUS != 'Discharging' ]] ; then
-    exit 0
+notify() {
+	level=$1
+	msg=$2
+	DISPLAY=:0 /usr/bin/notify-send -t 3500 -u "$level" "POWER" "$msg"
+}
+
+# Battery status changed
+if [[ "$BATTSTATUS" != "$LAST_STATUS" ]] ; then
+	notify "normal" "battery is now $BATTSTATUS, Capacity: $BATTPERC"
+	save_status
+	exit
 fi
 
-if [[ $BATTPERC == 50 ]] ; then
-    notify "low" "battery is at 50%"
-elif [[ $BATTPERC == 30 ]] ; then
-    notify "normal" "battery is at 30%"
-elif [[ "$BATTPERC | sed -e :a -e 's/^.\{1\}$/0&/;ta'" < 10 ]] ; then
-    notify "critical" "battery is less than 10%"
+if [ "$BATTSTATUS" = Discharging ] && [ "$BATTPERC" -le 10 ]; then
+	NOTIF_LEVEL=10
+	notify "critical" "battery is less than 10% - Connect charger, going to sleep in 10s"
+	sleep 10
+	BATTSTATUS=$(cat /sys/class/power_supply/BAT${BAT_NUM}/status)
+	if [ "$BATTSTATUS" = Discharging ]; then
+		notify "critical" "going to suspend now"
+		sleep 3
+		logger "Critical battery threshold, suspending"
+		systemctl suspend
+	else
+		notify "normal" "battery is now charging, cancelling suspend"
+	fi
+	save_status
+	exit
 fi
+
+if [[ $BATTPERC -le 20 ]] ; then
+	NOTIF_LEVEL=20
+	notify "critical" "battery $BATTSTATUS is less than 20%"
+	save_status
+elif [[ $BATTPERC -le 30 ]] ; then
+	NOTIF_LEVEL=30
+	if [ "$NOTIF_LEVEL" != "$LAST_NOTIF_LEVEL" ]; then
+		notify "normal" "battery $BATTSTATUS is at 30%"
+		save_status
+	fi
+elif [[ $BATTPERC -le 50 ]] ; then
+	NOTIF_LEVEL=50
+	if [ "$NOTIF_LEVEL" != "$LAST_NOTIF_LEVEL" ] ; then
+		notify "low" "battery $BATTSTATUS is at 50%"
+		save_status
+	fi
+elif [[ $BATTPERC -le 60 ]] ; then
+	NOTIF_LEVEL=60
+	if [ "$NOTIF_LEVEL" != "$LAST_NOTIF_LEVEL" ] ; then
+		notify "normal" "battery $BATTSTATUS is at 60%"
+		save_status
+	fi
+fi
+


### PR DESCRIPTION
- The state is now tracked in a temporary file
- This makes the status tracking better against race conditions
- There's a mechanism for suspension if the percentage is below 10% and the battery isn't connected within 10 seconds